### PR TITLE
issue #106: improve exception handling in `fertiscan`

### DIFF
--- a/fertiscan/__init__.py
+++ b/fertiscan/__init__.py
@@ -28,8 +28,8 @@ if FERTISCAN_STORAGE_URL is None or FERTISCAN_STORAGE_URL == "":
 
 
 async def register_analysis(
-    cursor,
-    container_client,
+    cursor: Cursor,
+    container_client: ContainerClient,
     user_id,
     hashed_pictures,
     analysis_dict,
@@ -46,44 +46,39 @@ async def register_analysis(
     Returns:
     - The analysis_dict with the analysis_id added.
     """
-    try:
-        if not user.is_a_user_id(cursor=cursor, user_id=user_id):
-            raise user.UserNotFoundError(
-                f"User not found based on the given id: {user_id}"
-            )
-        if not container_client.exists():
-            raise datastore.ContainerCreationError(
-                f"Container not found based on the given user_id: {user_id}"
-            )
-
-        # Create picture set for this analysis
-        picture_set_metadata = data_picture_set.build_picture_set(
-            user_id, len(hashed_pictures)
-        )
-        picture_set_id = picture.new_picture_set(cursor, picture_set_metadata, user_id)
-
-        await datastore.create_picture_set(
-            cursor, container_client, len(hashed_pictures), user_id, str(picture_set_id)
+    if not user.is_a_user_id(cursor=cursor, user_id=user_id):
+        raise user.UserNotFoundError(f"User not found based on the given id: {user_id}")
+    if not container_client.exists():
+        raise datastore.ContainerCreationError(
+            f"Container not found based on the given user_id: {user_id}"
         )
 
-        # Upload pictures to storage
-        await datastore.upload_pictures(
-            cursor=cursor,
-            user_id=user_id,
-            container_client=container_client,
-            picture_set_id=picture_set_id,
-            hashed_pictures=hashed_pictures,
-        )
+    # Create picture set for this analysis
+    picture_set_metadata = data_picture_set.build_picture_set(
+        user_id, len(hashed_pictures)
+    )
+    picture_set_id = picture.new_picture_set(cursor, picture_set_metadata, user_id)
 
-        # Register analysis in the database
-        formatted_analysis = data_inspection.build_inspection_import(analysis_dict)
+    await datastore.create_picture_set(
+        cursor, container_client, len(hashed_pictures), user_id, str(picture_set_id)
+    )
 
-        analysis_db = inspection.new_inspection_with_label_info(
-            cursor, user_id, picture_set_id, formatted_analysis
-        )
-        return analysis_db
-    except data_inspection.MissingKeyError:
-        raise
+    # Upload pictures to storage
+    await datastore.upload_pictures(
+        cursor=cursor,
+        user_id=user_id,
+        container_client=container_client,
+        picture_set_id=picture_set_id,
+        hashed_pictures=hashed_pictures,
+    )
+
+    # Register analysis in the database
+    formatted_analysis = data_inspection.build_inspection_import(analysis_dict)
+
+    analysis_db = inspection.new_inspection_with_label_info(
+        cursor, user_id, picture_set_id, formatted_analysis
+    )
+    return analysis_db
 
 
 async def update_inspection(
@@ -130,7 +125,7 @@ async def update_inspection(
 
 
 async def get_full_inspection_json(
-    cursor,
+    cursor: Cursor,
     inspection_id,
     user_id=None,
     picture_set_id=None,
@@ -148,85 +143,80 @@ async def get_full_inspection_json(
     Returns:
     - The inspection json.
     """
-    try:
-        if not inspection.is_a_inspection_id(
-            cursor=cursor, inspection_id=inspection_id
-        ):
-            raise inspection.InspectionNotFoundError(
-                f"Inspection not found based on the given id: {inspection_id}"
-            )
-
-        # Check Ids
-        if (
-            (
-                picture_set_id is None
-                or picture_set_id == ""
-                or not picture.is_a_picture_set_id(
-                    cursor=cursor, picture_set_id=picture_set_id
-                )
-            )
-            or (
-                user_id is None
-                or user_id == ""
-                or not user.is_a_user_id(cursor=cursor, user_id=user_id)
-            )
-            or (label_info_id is None or label_info_id == "")
-            or (company_info_id is None or company_info_id == "")
-            or (manufacturer_info_id is None or manufacturer_info_id == "")
-        ):
-            ids = inspection.get_inspection_fk(cursor, inspection_id)
-            picture_set_id = ids[2]
-            label_info_id = ids[0]
-            company_info_id = ids[3]
-            manufacturer_info_id = ids[4]
-            user_id = ids[1]
-        else:
-            if not picture.is_a_picture_set_id(
-                cursor=cursor, picture_set_id=picture_set_id
-            ):
-                raise picture.PictureSetNotFoundError(
-                    f"Picture set not found based on the given id: {picture_set_id}"
-                )
-            if not user.is_a_user_id(cursor=cursor, user_id=user_id):
-                raise user.UserNotFoundError(
-                    f"User not found based on the given id: {user_id}"
-                )
-            ids = inspection.get_inspection_fk(cursor, inspection_id)
-            if not picture_set_id == ids[2]:
-                raise Warning(
-                    "Picture set id does not match the picture_set_id in the inspection for the given inspection_id"
-                )
-            if not label_info_id == ids[0]:
-                raise Warning(
-                    "Label info id does not match the label_info_id in the inspection for the given inspection_id"
-                )
-            if not company_info_id == ids[3]:
-                raise Warning(
-                    "Company info id does not match the company_info_id in the inspection for the given inspection_id"
-                )
-            if not manufacturer_info_id == ids[4]:
-                raise Warning(
-                    "Manufacturer info id does not match the manufacturer_info_id in the inspection for the given inspection_id"
-                )
-            if not user_id == ids[1]:
-                raise Warning(
-                    "User id does not match the user_id in the inspection for the given inspection_id"
-                )
-
-        # Retrieve pictures
-        # pictures_ids = picture.get_picture_in_picture_set(cursor, picture_set_id)
-
-        # Retrieve label_info
-        inspection_metadata = data_inspection.build_inspection_export(
-            cursor, inspection_id, label_info_id
+    if not inspection.is_a_inspection_id(cursor=cursor, inspection_id=inspection_id):
+        raise inspection.InspectionNotFoundError(
+            f"Inspection not found based on the given id: {inspection_id}"
         )
 
-        return inspection_metadata
-    except inspection.InspectionNotFoundError:
-        raise
+    # Check Ids
+    if (
+        (
+            picture_set_id is None
+            or picture_set_id == ""
+            or not picture.is_a_picture_set_id(
+                cursor=cursor, picture_set_id=picture_set_id
+            )
+        )
+        or (
+            user_id is None
+            or user_id == ""
+            or not user.is_a_user_id(cursor=cursor, user_id=user_id)
+        )
+        or (label_info_id is None or label_info_id == "")
+        or (company_info_id is None or company_info_id == "")
+        or (manufacturer_info_id is None or manufacturer_info_id == "")
+    ):
+        ids = inspection.get_inspection_fk(cursor, inspection_id)
+        picture_set_id = ids[2]
+        label_info_id = ids[0]
+        company_info_id = ids[3]
+        manufacturer_info_id = ids[4]
+        user_id = ids[1]
+    else:
+        if not picture.is_a_picture_set_id(
+            cursor=cursor, picture_set_id=picture_set_id
+        ):
+            raise picture.PictureSetNotFoundError(
+                f"Picture set not found based on the given id: {picture_set_id}"
+            )
+        if not user.is_a_user_id(cursor=cursor, user_id=user_id):
+            raise user.UserNotFoundError(
+                f"User not found based on the given id: {user_id}"
+            )
+        ids = inspection.get_inspection_fk(cursor, inspection_id)
+        if not picture_set_id == ids[2]:
+            raise Warning(
+                "Picture set id does not match the picture_set_id in the inspection for the given inspection_id"
+            )
+        if not label_info_id == ids[0]:
+            raise Warning(
+                "Label info id does not match the label_info_id in the inspection for the given inspection_id"
+            )
+        if not company_info_id == ids[3]:
+            raise Warning(
+                "Company info id does not match the company_info_id in the inspection for the given inspection_id"
+            )
+        if not manufacturer_info_id == ids[4]:
+            raise Warning(
+                "Manufacturer info id does not match the manufacturer_info_id in the inspection for the given inspection_id"
+            )
+        if not user_id == ids[1]:
+            raise Warning(
+                "User id does not match the user_id in the inspection for the given inspection_id"
+            )
+
+    # Retrieve pictures
+    # pictures_ids = picture.get_picture_in_picture_set(cursor, picture_set_id)
+
+    # Retrieve label_info
+    inspection_metadata = data_inspection.build_inspection_export(
+        cursor, inspection_id, label_info_id
+    )
+
+    return inspection_metadata
 
 
-async def get_user_analysis_by_verified(cursor, user_id, verified: bool):
+async def get_user_analysis_by_verified(cursor: Cursor, user_id, verified: bool):
     """
     This function fetch all the inspection of a user
 
@@ -251,16 +241,9 @@ async def get_user_analysis_by_verified(cursor, user_id, verified: bool):
     ]
     """
 
-    try:
-        if not user.is_a_user_id(cursor=cursor, user_id=user_id):
-            raise user.UserNotFoundError(
-                f"User not found based on the given id: {user_id}"
-            )
-        return inspection.get_all_user_inspection_filter_verified(
-            cursor, user_id, verified
-        )
-    except user.UserNotFoundError:
-        raise
+    if not user.is_a_user_id(cursor=cursor, user_id=user_id):
+        raise user.UserNotFoundError(f"User not found based on the given id: {user_id}")
+    return inspection.get_all_user_inspection_filter_verified(cursor, user_id, verified)
 
 
 async def delete_inspection(

--- a/fertiscan/db/metadata/errors.py
+++ b/fertiscan/db/metadata/errors.py
@@ -1,0 +1,20 @@
+class MetadataError(Exception):
+    """Base exception for metadata errors"""
+
+    pass
+
+
+class BuildInspectionImportError(MetadataError):
+    """Error raised when building the inspection import fails"""
+
+    pass
+
+
+class BuildInspectionExportError(MetadataError):
+    """Error raised when building the inspection export fails"""
+
+    pass
+
+
+class NPKError(MetadataError):
+    pass

--- a/fertiscan/db/metadata/inspection/__init__.py
+++ b/fertiscan/db/metadata/inspection/__init__.py
@@ -433,22 +433,27 @@ def extract_npk(npk: str):
     Returns:
     - A list containing the npk values.
     """
-    if npk is None or npk == "" or len(npk) < 5:
-        return [None, None, None]
-    npk_formated = npk.replace("N", "-")
-    npk_formated = npk_formated.replace("P", "-")
-    npk_formated = npk_formated.replace("K", "-")
-    npk_reformated = npk.split("-")
-    for i in range(len(npk_reformated)):
-        if not npk_reformated[i].isnumeric():
-            NPKError(
-                "NPK values must be numeric. Issue with: "
-                + npk_reformated[i]
-                + "in the NPK string: "
-                + npk
-            )
-    return [
-        float(npk_reformated[0]),
-        float(npk_reformated[1]),
-        float(npk_reformated[2]),
-    ]
+    try:
+        if npk is None or npk == "" or len(npk) < 5:
+            return [None, None, None]
+        npk_formated = npk.replace("N", "-")
+        npk_formated = npk_formated.replace("P", "-")
+        npk_formated = npk_formated.replace("K", "-")
+        npk_reformated = npk.split("-")
+        for i in range(len(npk_reformated)):
+            if not npk_reformated[i].isnumeric():
+                NPKError(
+                    "NPK values must be numeric. Issue with: "
+                    + npk_reformated[i]
+                    + "in the NPK string: "
+                    + npk
+                )
+        return [
+            float(npk_reformated[0]),
+            float(npk_reformated[1]),
+            float(npk_reformated[2]),
+        ]
+    except NPKError:
+        raise
+    except Exception as e:
+        raise NPKError(f"Unexpected error: {e}") from e

--- a/fertiscan/db/metadata/inspection/__init__.py
+++ b/fertiscan/db/metadata/inspection/__init__.py
@@ -9,28 +9,21 @@ from typing import List, Optional
 
 from pydantic import UUID4, BaseModel, ValidationError, model_validator
 
+from fertiscan.db.metadata.errors import (
+    BuildInspectionExportError,
+    BuildInspectionImportError,
+    MetadataError,
+    NPKError,
+)
 from fertiscan.db.queries import (
-    ingredient,
     inspection,
     label,
     metric,
     nutrients,
     organization,
-    specification,
     sub_label,
 )
-
-
-class MissingKeyError(Exception):
-    pass
-
-
-class NPKError(Exception):
-    pass
-
-
-class MetadataFormattingError(Exception):
-    pass
+from fertiscan.db.queries.errors import QueryError
 
 
 class ValidatedModel(BaseModel):
@@ -180,7 +173,9 @@ def build_inspection_import(analysis_form: dict) -> str:
             if key not in analysis_form:
                 missing_keys.append(key)
         if len(missing_keys) > 0:
-            raise MissingKeyError(missing_keys)
+            raise BuildInspectionImportError(
+                f"The analysis form is missing keys: {missing_keys}"
+            )
 
         npk = extract_npk(analysis_form.get("npk"))
 
@@ -335,16 +330,13 @@ def build_inspection_import(analysis_form: dict) -> str:
             guaranteed_analysis=guaranteed,
         )
         Inspection(**inspection_formatted.model_dump())
-    except MissingKeyError as e:
-        raise MissingKeyError("Missing keys:" + str(e))
+        return inspection_formatted.model_dump_json()
+    except MetadataError:
+        raise
     except ValidationError as e:
-        print(analysis_form.get("cautions_en", []))
-        print(analysis_form.get("cautions_fr", []))
-        raise MetadataFormattingError(
-            "Error InspectionCreationError not created: " + str(e)
-        ) from None
-    # print(inspection_formatted.model_dump_json())
-    return inspection_formatted.model_dump_json()
+        raise BuildInspectionImportError(f"Validation error: {e}") from e
+    except Exception as e:
+        raise BuildInspectionImportError(f"Unexpected error: {e}") from e
 
 
 def build_inspection_export(cursor, inspection_id, label_info_id) -> str:
@@ -396,21 +388,10 @@ def build_inspection_export(cursor, inspection_id, label_info_id) -> str:
         )
 
         return inspection_formatted.model_dump_json()
-    except (
-        label.LabelInformationNotFoundError
-        or metric.MetricNotFoundError
-        or organization.OrganizationNotFoundError
-        or sub_label.SubLabelNotFoundError
-        or ingredient.IngredientNotFoundError
-        or nutrients.MicronutrientNotFoundError
-        or nutrients.GuaranteedNotFoundError
-        or specification.SpecificationNotFoundError
-    ):
-        raise
+    except QueryError as e:
+        raise BuildInspectionExportError(f"Error fetching data: {e}") from e
     except Exception as e:
-        raise MetadataFormattingError(
-            "Error Inspection Form not created: " + str(e)
-        ) from e
+        raise BuildInspectionImportError(f"Unexpected error: {e}") from e
 
 
 def split_value_unit(value_unit: str) -> dict:

--- a/fertiscan/db/queries/errors.py
+++ b/fertiscan/db/queries/errors.py
@@ -1,0 +1,569 @@
+from functools import wraps
+
+from psycopg import Error
+
+
+class QueryError(Exception):
+    """Base exception for all query errors."""
+
+    pass
+
+
+class InspectionQueryError(QueryError):
+    """Base exception for all inspection-related query errors."""
+
+    pass
+
+
+class InspectionNotFoundError(InspectionQueryError):
+    """Raised when an inspection is not found."""
+
+    pass
+
+
+class InspectionCreationError(InspectionQueryError):
+    """Raised when an error occurs during the creation of an inspection."""
+
+    pass
+
+
+class InspectionUpdateError(InspectionQueryError):
+    """Raised when an error occurs during the updating of an inspection."""
+
+    pass
+
+
+class InspectionRetrievalError(InspectionQueryError):
+    """Raised when an error occurs during the retrieval of an inspection."""
+
+    pass
+
+
+class InspectionDeleteError(InspectionQueryError):
+    """Raised when an error occurs during the deletion of an inspection."""
+
+    pass
+
+
+class LabelInformationQueryError(QueryError):
+    """Base exception for all label information-related query errors."""
+
+    pass
+
+
+class LabelInformationNotFoundError(LabelInformationQueryError):
+    """Raised when a label information is not found."""
+
+    pass
+
+
+class LabelInformationCreationError(LabelInformationQueryError):
+    """Raised when an error occurs during the creation of a label information."""
+
+    pass
+
+
+class LabelInformationUpdateError(LabelInformationQueryError):
+    """Raised when an error occurs during the updating of a label information."""
+
+    pass
+
+
+class LabelInformationRetrievalError(LabelInformationQueryError):
+    """Raised when an error occurs during the retrieval of a label information."""
+
+    pass
+
+
+class LabelInformationDeleteError(LabelInformationQueryError):
+    """Raised when an error occurs during the deletion of a label information."""
+
+    pass
+
+
+class MetricQueryError(QueryError):
+    """Base exception for all metric-related query errors."""
+
+    pass
+
+
+class MetricNotFoundError(MetricQueryError):
+    """Raised when a metric is not found."""
+
+    pass
+
+
+class MetricCreationError(MetricQueryError):
+    """Raised when an error occurs during the creation of a metric."""
+
+    pass
+
+
+class MetricUpdateError(MetricQueryError):
+    """Raised when an error occurs during the updating of a metric."""
+
+    pass
+
+
+class MetricRetrievalError(MetricQueryError):
+    """Raised when an error occurs during the retrieval of a metric."""
+
+    pass
+
+
+class MetricDeleteError(MetricQueryError):
+    """Raised when an error occurs during the deletion of a metric."""
+
+    pass
+
+
+class UnitQueryError(QueryError):
+    """Base exception for all unit-related query errors."""
+
+    pass
+
+
+class UnitNotFoundError(UnitQueryError):
+    """Raised when a unit is not found."""
+
+    pass
+
+
+class UnitCreationError(UnitQueryError):
+    """Raised when an error occurs during the creation of a unit."""
+
+    pass
+
+
+class UnitUpdateError(UnitQueryError):
+    """Raised when an error occurs during the updating of a unit."""
+
+    pass
+
+
+class UnitRetrievalError(UnitQueryError):
+    """Raised when an error occurs during the retrieval of a unit."""
+
+    pass
+
+
+class UnitDeleteError(UnitQueryError):
+    """Raised when an error occurs during the deletion of a unit."""
+
+    pass
+
+
+class ElementCompoundQueryError(QueryError):
+    """Base exception for all element compound-related query errors."""
+
+    pass
+
+
+class ElementCompoundNotFoundError(ElementCompoundQueryError):
+    """Raised when an element compound is not found."""
+
+    pass
+
+
+class ElementCompoundCreationError(ElementCompoundQueryError):
+    """Raised when an error occurs during the creation of an element compound."""
+
+    pass
+
+
+class ElementCompoundUpdateError(ElementCompoundQueryError):
+    """Raised when an error occurs during the updating of an element compound."""
+
+    pass
+
+
+class ElementCompoundRetrievalError(ElementCompoundQueryError):
+    """Raised when an error occurs during the retrieval of an element compound."""
+
+    pass
+
+
+class ElementCompoundDeleteError(ElementCompoundQueryError):
+    """Raised when an error occurs during the deletion of an element compound."""
+
+    pass
+
+
+class MicronutrientQueryError(QueryError):
+    """Base exception for all micronutrient-related query errors."""
+
+    pass
+
+
+class MicronutrientNotFoundError(MicronutrientQueryError):
+    """Raised when a micronutrient is not found."""
+
+    pass
+
+
+class MicronutrientCreationError(MicronutrientQueryError):
+    """Raised when an error occurs during the creation of a micronutrient."""
+
+    pass
+
+
+class MicronutrientUpdateError(MicronutrientQueryError):
+    """Raised when an error occurs during the updating of a micronutrient."""
+
+    pass
+
+
+class MicronutrientRetrievalError(MicronutrientQueryError):
+    """Raised when an error occurs during the retrieval of a micronutrient."""
+
+    pass
+
+
+class MicronutrientDeleteError(MicronutrientQueryError):
+    """Raised when an error occurs during the deletion of a micronutrient."""
+
+    pass
+
+
+class GuaranteedAnalysisQueryError(QueryError):
+    """Base exception for all guaranteed analysis-related query errors."""
+
+    pass
+
+
+class GuaranteedAnalysisNotFoundError(GuaranteedAnalysisQueryError):
+    """Raised when a guaranteed analysis is not found."""
+
+    pass
+
+
+class GuaranteedAnalysisCreationError(GuaranteedAnalysisQueryError):
+    """Raised when an error occurs during the creation of a guaranteed analysis."""
+
+    pass
+
+
+class GuaranteedAnalysisUpdateError(GuaranteedAnalysisQueryError):
+    """Raised when an error occurs during the updating of a guaranteed analysis."""
+
+    pass
+
+
+class GuaranteedAnalysisRetrievalError(GuaranteedAnalysisQueryError):
+    """Raised when an error occurs during the retrieval of a guaranteed analysis."""
+
+    pass
+
+
+class GuaranteedAnalysisDeleteError(GuaranteedAnalysisQueryError):
+    """Raised when an error occurs during the deletion of a guaranteed analysis."""
+
+    pass
+
+
+class OrganizationQueryError(QueryError):
+    """Base exception for all organization-related query errors."""
+
+    pass
+
+
+class OrganizationNotFoundError(OrganizationQueryError):
+    """Raised when an organization is not found."""
+
+    pass
+
+
+class OrganizationCreationError(OrganizationQueryError):
+    """Raised when an error occurs during the creation of an organization."""
+
+    pass
+
+
+class OrganizationUpdateError(OrganizationQueryError):
+    """Raised when an error occurs during the updating of an organization."""
+
+    pass
+
+
+class OrganizationRetrievalError(OrganizationQueryError):
+    """Raised when an error occurs during the retrieval of an organization."""
+
+    pass
+
+
+class OrganizationDeleteError(OrganizationQueryError):
+    """Raised when an error occurs during the deletion of an organization."""
+
+    pass
+
+
+class OrganizationInformationQueryError(QueryError):
+    """Base exception for all organization information-related query errors."""
+
+    pass
+
+
+class OrganizationInformationNotFoundError(OrganizationInformationQueryError):
+    """Raised when organization information is not found."""
+
+    pass
+
+
+class OrganizationInformationCreationError(OrganizationInformationQueryError):
+    """Raised when an error occurs during the creation of organization information."""
+
+    pass
+
+
+class OrganizationInformationUpdateError(OrganizationInformationQueryError):
+    """Raised when an error occurs during the updating of organization information."""
+
+    pass
+
+
+class OrganizationInformationRetrievalError(OrganizationInformationQueryError):
+    """Raised when an error occurs during the retrieval of organization information."""
+
+    pass
+
+
+class OrganizationInformationDeleteError(OrganizationInformationQueryError):
+    """Raised when an error occurs during the deletion of organization information."""
+
+    pass
+
+
+class LocationQueryError(QueryError):
+    """Base exception for all location-related query errors."""
+
+    pass
+
+
+class LocationNotFoundError(LocationQueryError):
+    """Raised when a location is not found."""
+
+    pass
+
+
+class LocationCreationError(LocationQueryError):
+    """Raised when an error occurs during the creation of a location."""
+
+    pass
+
+
+class LocationUpdateError(LocationQueryError):
+    """Raised when an error occurs during the updating of a location."""
+
+    pass
+
+
+class LocationRetrievalError(LocationQueryError):
+    """Raised when an error occurs during the retrieval of a location."""
+
+    pass
+
+
+class LocationDeleteError(LocationQueryError):
+    """Raised when an error occurs during the deletion of a location."""
+
+    pass
+
+
+class RegionQueryError(QueryError):
+    """Base exception for all region-related query errors."""
+
+    pass
+
+
+class RegionNotFoundError(RegionQueryError):
+    """Raised when a region is not found."""
+
+    pass
+
+
+class RegionCreationError(RegionQueryError):
+    """Raised when an error occurs during the creation of a region."""
+
+    pass
+
+
+class RegionUpdateError(RegionQueryError):
+    """Raised when an error occurs during the updating of a region."""
+
+    pass
+
+
+class RegionRetrievalError(RegionQueryError):
+    """Raised when an error occurs during the retrieval of a region."""
+
+    pass
+
+
+class RegionDeleteError(RegionQueryError):
+    """Raised when an error occurs during the deletion of a region."""
+
+    pass
+
+
+class ProvinceQueryError(QueryError):
+    """Base exception for all province-related query errors."""
+
+    pass
+
+
+class ProvinceNotFoundError(ProvinceQueryError):
+    """Raised when a province is not found."""
+
+    pass
+
+
+class ProvinceCreationError(ProvinceQueryError):
+    """Raised when an error occurs during the creation of a province."""
+
+    pass
+
+
+class ProvinceUpdateError(ProvinceQueryError):
+    """Raised when an error occurs during the updating of a province."""
+
+    pass
+
+
+class ProvinceRetrievalError(ProvinceQueryError):
+    """Raised when an error occurs during the retrieval of a province."""
+
+    pass
+
+
+class ProvinceDeleteError(ProvinceQueryError):
+    """Raised when an error occurs during the deletion of a province."""
+
+    pass
+
+
+class SpecificationQueryError(QueryError):
+    """Base exception for all specification-related query errors."""
+
+    pass
+
+
+class SpecificationNotFoundError(SpecificationQueryError):
+    """Raised when a specification is not found."""
+
+    pass
+
+
+class SpecificationCreationError(SpecificationQueryError):
+    """Raised when an error occurs during the creation of a specification."""
+
+    pass
+
+
+class SpecificationUpdateError(SpecificationQueryError):
+    """Raised when an error occurs during the updating of a specification."""
+
+    pass
+
+
+class SpecificationRetrievalError(SpecificationQueryError):
+    """Raised when an error occurs during the retrieval of a specification."""
+
+    pass
+
+
+class SpecificationDeleteError(SpecificationQueryError):
+    """Raised when an error occurs during the deletion of a specification."""
+
+    pass
+
+
+class SubLabelQueryError(QueryError):
+    """Base exception for all sublabel-related query errors."""
+
+    pass
+
+
+class SubLabelNotFoundError(SubLabelQueryError):
+    """Raised when a sublabel is not found."""
+
+    pass
+
+
+class SubLabelCreationError(SubLabelQueryError):
+    """Raised when an error occurs during the creation of a sublabel."""
+
+    pass
+
+
+class SubLabelUpdateError(SubLabelQueryError):
+    """Raised when an error occurs during the updating of a sublabel."""
+
+    pass
+
+
+class SubLabelRetrievalError(SubLabelQueryError):
+    """Raised when an error occurs during the retrieval of a sublabel."""
+
+    pass
+
+
+class SubLabelDeleteError(SubLabelQueryError):
+    """Raised when an error occurs during the deletion of a sublabel."""
+
+    pass
+
+
+class SubTypeQueryError(QueryError):
+    """Base exception for all subtype-related query errors."""
+
+    pass
+
+
+class SubTypeNotFoundError(SubTypeQueryError):
+    """Raised when a subtype is not found."""
+
+    pass
+
+
+class SubTypeCreationError(SubTypeQueryError):
+    """Raised when an error occurs during the creation of a subtype."""
+
+    pass
+
+
+class SubTypeUpdateError(SubTypeQueryError):
+    """Raised when an error occurs during the updating of a subtype."""
+
+    pass
+
+
+class SubTypeRetrievalError(SubTypeQueryError):
+    """Raised when an error occurs during the retrieval of a subtype."""
+
+    pass
+
+
+class SubTypeDeleteError(SubTypeQueryError):
+    """Raised when an error occurs during the deletion of a subtype."""
+
+    pass
+
+
+def handle_query_errors(error_cls=QueryError):
+    """Decorator for handling query errors."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except QueryError:
+                raise
+            except Error as db_error:
+                raise error_cls(f"Database error: {db_error}") from db_error
+            except Exception as e:
+                raise error_cls(f"Unexpected error: {e}") from e
+
+        return wrapper
+
+    return decorator

--- a/fertiscan/db/queries/errors.py
+++ b/fertiscan/db/queries/errors.py
@@ -5,6 +5,7 @@ Query exceptions hierarchy:
     |__QueryError
        |__InspectionQueryError
        |__LabelInformationQueryError
+       |__LabelDimensionQueryError
        |__MetricQueryError
        |__UnitQueryError
        |__ElementCompoundQueryError
@@ -101,6 +102,18 @@ class LabelInformationRetrievalError(LabelInformationQueryError):
 
 class LabelInformationDeleteError(LabelInformationQueryError):
     """Raised when an error occurs during the deletion of a label information."""
+
+    pass
+
+
+class LabelDimensionQueryError(QueryError):
+    """Base exception for all label dimension-related query errors."""
+
+    pass
+
+
+class LabelDimensionNotFoundError(LabelDimensionQueryError):
+    """Raised when a label dimension is not found."""
 
     pass
 

--- a/fertiscan/db/queries/errors.py
+++ b/fertiscan/db/queries/errors.py
@@ -20,7 +20,7 @@ Query exceptions hierarchy:
        |__SubLabelQueryError
        |__SubTypeQueryError
 
-Each QueryError sub type exception has specific errors related to creation, retrieval, updating, and deletion, as well as a 'not found' error.
+Each QueryError sub type exception also has specific errors sub types related to creation, retrieval, updating, and deletion, as well as a 'not found' error.
 """
 
 from functools import wraps

--- a/fertiscan/db/queries/label/__init__.py
+++ b/fertiscan/db/queries/label/__init__.py
@@ -5,9 +5,10 @@ This module represent the function for the table label_information
 from psycopg import Cursor
 
 from fertiscan.db.queries.errors import (
+    LabelDimensionNotFoundError,
+    LabelDimensionQueryError,
     LabelInformationCreationError,
     LabelInformationNotFoundError,
-    LabelInformationQueryError,
     LabelInformationRetrievalError,
     handle_query_errors,
 )
@@ -146,7 +147,7 @@ def get_label_information_json(cursor, label_info_id) -> dict:
     return label_info[0]
 
 
-@handle_query_errors(LabelInformationQueryError)
+@handle_query_errors(LabelDimensionQueryError)
 def get_label_dimension(cursor, label_id):
     """
     This function get the label_dimension from the database.
@@ -184,7 +185,7 @@ def get_label_dimension(cursor, label_id):
     cursor.execute(query, (label_id,))
     data = cursor.fetchone()
     if data is None or data[0] is None:
-        raise LabelInformationQueryError(
+        raise LabelDimensionNotFoundError(
             "Error: could not get the label dimension for label: " + str(label_id)
         )
     return data

--- a/fertiscan/db/queries/label/__init__.py
+++ b/fertiscan/db/queries/label/__init__.py
@@ -184,7 +184,7 @@ def get_label_dimension(cursor, label_id):
     cursor.execute(query, (label_id,))
     data = cursor.fetchone()
     if data is None or data[0] is None:
-        raise LabelInformationNotFoundError(
+        raise LabelInformationQueryError(
             "Error: could not get the label dimension for label: " + str(label_id)
         )
     return data

--- a/fertiscan/db/queries/sub_label/__init__.py
+++ b/fertiscan/db/queries/sub_label/__init__.py
@@ -3,24 +3,24 @@ This module represent the function for the sub table of label_information
 
 """
 
+from psycopg import Cursor
 
-class SubLabelCreationError(Exception):
-    pass
-
-
-class SubLabelNotFoundError(Exception):
-    pass
-
-
-class SubTypeCreationError(Exception):
-    pass
-
-
-class SubTypeNotFoundError(Exception):
-    pass
+from fertiscan.db.queries.errors import (
+    SubLabelCreationError,
+    SubLabelNotFoundError,
+    SubLabelQueryError,
+    SubLabelRetrievalError,
+    SubLabelUpdateError,
+    SubTypeCreationError,
+    SubTypeQueryError,
+    handle_query_errors,
+)
 
 
-def new_sub_label(cursor, text_fr, text_en, label_id, sub_type_id, edited=False):
+@handle_query_errors(SubLabelCreationError)
+def new_sub_label(
+    cursor: Cursor, text_fr, text_en, label_id, sub_type_id, edited=False
+):
     """
     This function creates a new sub label in the database.
 
@@ -35,17 +35,17 @@ def new_sub_label(cursor, text_fr, text_en, label_id, sub_type_id, edited=False)
     Returns:
     - The UUID of the new sub label.
     """
-    try:
-        query = """
-            SELECT new_sub_label(%s, %s, %s, %s, %s);
-        """
-        cursor.execute(query, (text_fr, text_en, label_id, sub_type_id, edited))
-        return cursor.fetchone()[0]
-    except Exception:
-        raise SubLabelCreationError("Error: could not create the sub label")
+    query = """
+        SELECT new_sub_label(%s, %s, %s, %s, %s);
+    """
+    cursor.execute(query, (text_fr, text_en, label_id, sub_type_id, edited))
+    if result := cursor.fetchone():
+        return result[0]
+    raise SubLabelCreationError("Failed to create SubLabel. No data returned.")
 
 
-def get_sub_label(cursor, sub_label_id):
+@handle_query_errors(SubLabelRetrievalError)
+def get_sub_label(cursor: Cursor, sub_label_id):
     """
     This function gets the sub label from the database.
 
@@ -56,26 +56,24 @@ def get_sub_label(cursor, sub_label_id):
     Returns:
     - The sub label entity.
     """
-    try:
-        query = """
-            SELECT 
-                text_content_fr,
-                text_content_en,
-                edited,
-                label_id,
-                sub_type_id
-            FROM 
-                sub_label
-            WHERE 
-                id = %s
-        """
-        cursor.execute(query, (sub_label_id,))
-        return cursor.fetchone()
-    except Exception:
-        raise SubLabelNotFoundError("Error: could not get the sub label")
+    query = """
+        SELECT 
+            text_content_fr,
+            text_content_en,
+            edited,
+            label_id,
+            sub_type_id
+        FROM 
+            sub_label
+        WHERE 
+            id = %s
+    """
+    cursor.execute(query, (sub_label_id,))
+    return cursor.fetchone()
 
 
-def has_sub_label(cursor, label_id):
+@handle_query_errors(SubLabelQueryError)
+def has_sub_label(cursor: Cursor, label_id):
     """
     This function checks if a label has sub label.
 
@@ -86,25 +84,27 @@ def has_sub_label(cursor, label_id):
     Returns:
     - True if the label has sub label, False otherwise.
     """
-    try:
-        query = """
-            SELECT 
-                Exists(
-                    SELECT 1
-                    FROM
-                        sub_label
-                    WHERE
-                        label_id = %s
-                    Limit 1
-                );
-        """
-        cursor.execute(query, (label_id,))
-        return cursor.fetchone()[0]
-    except Exception:
-        raise SubLabelNotFoundError("Error: could not check if the label has sub label")
+    query = """
+        SELECT 
+            Exists(
+                SELECT 1
+                FROM
+                    sub_label
+                WHERE
+                    label_id = %s
+                Limit 1
+            );
+    """
+    cursor.execute(query, (label_id,))
+    if result := cursor.fetchone():
+        return result[0]
+    raise SubLabelQueryError(
+        "Failed to check if label has sub label. No data returned."
+    )
 
 
-def get_sub_label_json(cursor, label_id) -> dict:
+@handle_query_errors(SubLabelRetrievalError)
+def get_sub_label_json(cursor: Cursor, label_id) -> dict:
     """
     This function gets all the sub label for a label in a json format.
 
@@ -115,26 +115,23 @@ def get_sub_label_json(cursor, label_id) -> dict:
     Returns:
     - The sub label in dict format.
     """
-    try:
-        if not has_sub_label(cursor, label_id):
-            return {
-                "cautions": {"en": [], "fr": []},
-                "instructions": {"en": [], "fr": []},
-                "first_aid": {"en": [], "fr": []},
-            }
-        query = """
-            SELECT get_sub_label_json(%s);
-            """
-        cursor.execute(query, (str(label_id),))
-        sub_label = cursor.fetchone()
-        return sub_label[0]
-    except SubLabelNotFoundError as e:
-        raise e
-    except Exception:
-        raise
+    if not has_sub_label(cursor, label_id):
+        return {
+            "cautions": {"en": [], "fr": []},
+            "instructions": {"en": [], "fr": []},
+            "first_aid": {"en": [], "fr": []},
+        }
+    query = """
+        SELECT get_sub_label_json(%s);
+        """
+    cursor.execute(query, (str(label_id),))
+    if result := cursor.fetchone():
+        return result[0]
+    raise SubLabelNotFoundError("No sub label found for label_id: " + str(label_id))
 
 
-def get_full_sub_label(cursor, sub_label_id):
+@handle_query_errors(SubLabelRetrievalError)
+def get_full_sub_label(cursor: Cursor, sub_label_id):
     """
     This function gets the full sub label from the database.
 
@@ -145,31 +142,29 @@ def get_full_sub_label(cursor, sub_label_id):
     Returns:
     - The full sub label entity.
     """
-    try:
-        query = """
-            SELECT 
-                sub_label.id,
-                sub_label.text_content_fr,
-                sub_label.text_content_en,
-                sub_label.edited,
-                sub_type.type_fr,
-                sub_type.type_en
-            FROM 
-                sub_label
-            JOIN 
-                sub_type
-            ON 
-                sub_label.sub_type_id = sub_type.id
-            WHERE 
-                sub_label.id = %s
-        """
-        cursor.execute(query, (sub_label_id,))
-        return cursor.fetchone()
-    except Exception:
-        raise SubLabelNotFoundError("Error: could not get the full sub label")
+    query = """
+        SELECT 
+            sub_label.id,
+            sub_label.text_content_fr,
+            sub_label.text_content_en,
+            sub_label.edited,
+            sub_type.type_fr,
+            sub_type.type_en
+        FROM 
+            sub_label
+        JOIN 
+            sub_type
+        ON 
+            sub_label.sub_type_id = sub_type.id
+        WHERE 
+            sub_label.id = %s
+    """
+    cursor.execute(query, (sub_label_id,))
+    return cursor.fetchone()
 
 
-def get_all_sub_label(cursor, label_id):
+@handle_query_errors(SubLabelRetrievalError)
+def get_all_sub_label(cursor: Cursor, label_id):
     """
     This function gets all the sub label from the database.
 
@@ -180,33 +175,31 @@ def get_all_sub_label(cursor, label_id):
     Returns:
     - The list of sub label entity.
     """
-    try:
-        query = """
-            SELECT 
-                sub_label.id,
-                sub_label.text_content_fr,
-                sub_label.text_content_en,
-                sub_label.edited,
-                sub_type.type_fr,
-                sub_type.type_en
-            FROM 
-                sub_label
-            JOIN
-                sub_type
-            ON
-                sub_label.sub_type_id = sub_type.id
-            WHERE 
-                label_id = %s
-            ORDER BY
-                sub_type.type_en
-        """
-        cursor.execute(query, (label_id,))
-        return cursor.fetchall()
-    except Exception:
-        raise SubLabelNotFoundError("Error: could not get the sub label")
+    query = """
+        SELECT 
+            sub_label.id,
+            sub_label.text_content_fr,
+            sub_label.text_content_en,
+            sub_label.edited,
+            sub_type.type_fr,
+            sub_type.type_en
+        FROM 
+            sub_label
+        JOIN
+            sub_type
+        ON
+            sub_label.sub_type_id = sub_type.id
+        WHERE 
+            label_id = %s
+        ORDER BY
+            sub_type.type_en
+    """
+    cursor.execute(query, (label_id,))
+    return cursor.fetchall()
 
 
-def update_sub_label(cursor, sub_label_id, text_fr, text_en, edited=True):
+@handle_query_errors(SubLabelUpdateError)
+def update_sub_label(cursor: Cursor, sub_label_id, text_fr, text_en, edited=True):
     """
     This function updates the sub label in the database.
 
@@ -220,23 +213,21 @@ def update_sub_label(cursor, sub_label_id, text_fr, text_en, edited=True):
     Returns:
     - None
     """
-    try:
-        query = """
-            UPDATE 
-                sub_label
-            SET 
-                text_content_fr = %s,
-                text_content_en = %s,
-                edited = %s
-            WHERE 
-                id = %s
-        """
-        cursor.execute(query, (text_fr, text_en, edited, sub_label_id))
-    except Exception:
-        raise SubLabelNotFoundError("Error: could not update the sub label")
+    query = """
+        UPDATE 
+            sub_label
+        SET 
+            text_content_fr = %s,
+            text_content_en = %s,
+            edited = %s
+        WHERE 
+            id = %s
+    """
+    cursor.execute(query, (text_fr, text_en, edited, sub_label_id))
 
 
-def new_sub_type(cursor, type_fr, type_en):
+@handle_query_errors(SubTypeCreationError)
+def new_sub_type(cursor: Cursor, type_fr, type_en):
     """
     This function creates a new sub type in the database.
 
@@ -248,22 +239,22 @@ def new_sub_type(cursor, type_fr, type_en):
     Returns:
     - The UUID of the new sub type.
     """
-    try:
-        query = """
-            INSERT INTO 
-                sub_type (type_fr, type_en)
-            VALUES 
-                (%s, %s)
-            RETURNING 
-                id
-        """
-        cursor.execute(query, (type_fr, type_en))
-        return cursor.fetchone()[0]
-    except Exception:
-        raise SubTypeCreationError("Error: could not create the sub type")
+    query = """
+        INSERT INTO 
+            sub_type (type_fr, type_en)
+        VALUES 
+            (%s, %s)
+        RETURNING 
+            id
+    """
+    cursor.execute(query, (type_fr, type_en))
+    if result := cursor.fetchone():
+        return result[0]
+    raise SubTypeCreationError("Failed to create SubType. No data returned.")
 
 
-def get_sub_type_id(cursor, type_name):
+@handle_query_errors(SubTypeQueryError)
+def get_sub_type_id(cursor: Cursor, type_name):
     """
     This function gets the sub type from the database.
 
@@ -274,22 +265,21 @@ def get_sub_type_id(cursor, type_name):
     Returns:
     - The UUID of the sub type.
     """
-    try:
-        query = """
-            SELECT 
-                id
-            FROM 
-                sub_type
-            WHERE 
-                type_fr ILIKE %s OR type_en ILIKE %s
-        """
-        cursor.execute(
-            query,
-            (
-                type_name,
-                type_name,
-            ),
-        )
-        return cursor.fetchone()[0]
-    except Exception:
-        raise SubTypeNotFoundError("Error: could not get the sub type")
+    query = """
+        SELECT 
+            id
+        FROM 
+            sub_type
+        WHERE 
+            type_fr ILIKE %s OR type_en ILIKE %s
+    """
+    cursor.execute(
+        query,
+        (
+            type_name,
+            type_name,
+        ),
+    )
+    if result := cursor.fetchone():
+        return result[0]
+    raise SubTypeQueryError("Failed to get the sub type id. No data returned.")

--- a/fertiscan_pyproject.toml
+++ b/fertiscan_pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "fertiscan_datastore"
 version = "1.0.4"
 authors = [
-  { name="Francois Werbrouck", email="francois.werbrouck@inspection.gc.ca" }
+  { name="Francois Werbrouck", email="francois.werbrouck@inspection.gc.ca" },
   { name="Kotchikpa Guy-Landry Allagbe" , email = "kotchikpaguy-landry.allagbe@inspection.gc.ca"}
 ]
 description = "Data management python layer"

--- a/fertiscan_pyproject.toml
+++ b/fertiscan_pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fertiscan_datastore"
-version = "1.0.2"
+version = "1.0.3"
 authors = [
   { name="Francois Werbrouck", email="francois.werbrouck@inspection.gc.ca" }
 ]

--- a/tests/fertiscan/db/test_guaranteed_analysis.py
+++ b/tests/fertiscan/db/test_guaranteed_analysis.py
@@ -7,8 +7,9 @@ import os
 import unittest
 
 import datastore.db as db
-from fertiscan.db.metadata import inspection as metadata
 from datastore.db.metadata import validator
+from fertiscan.db.metadata import inspection as metadata
+from fertiscan.db.queries import errors as e
 from fertiscan.db.queries import label, nutrients
 
 DB_CONNECTION_STRING = os.environ.get("FERTISCAN_DB_URL")
@@ -78,19 +79,19 @@ class test_element(unittest.TestCase):
 
     def test_get_element_error(self):
         self.assertRaises(
-            nutrients.ElementNotFoundError,
+            e.ElementCompoundNotFoundError,
             nutrients.get_element_id_full_search,
             self.cursor,
             "not-an-element",
         )
         self.assertRaises(
-            nutrients.ElementNotFoundError,
+            e.ElementCompoundNotFoundError,
             nutrients.get_element_id_name,
             self.cursor,
             "not-an-element",
         )
         self.assertRaises(
-            nutrients.ElementNotFoundError,
+            e.ElementCompoundNotFoundError,
             nutrients.get_element_id_symbol,
             self.cursor,
             "not-an-element",
@@ -170,7 +171,7 @@ class test_guaranteed_analysis(unittest.TestCase):
         self.assertTrue(validator.is_valid_uuid(guaranteed_analysis_id))
 
     def test_new_guaranteed_analysis_empty(self):
-        with self.assertRaises(nutrients.GuaranteedCreationError):
+        with self.assertRaises(e.GuaranteedAnalysisCreationError):
             nutrients.new_guaranteed_analysis(
                 self.cursor,
                 None,

--- a/tests/fertiscan/db/test_organization.py
+++ b/tests/fertiscan/db/test_organization.py
@@ -208,7 +208,7 @@ class test_organization_information(unittest.TestCase):
         self.assertTrue(validator.is_valid_uuid(id))
 
     def test_new_organization_located_empty(self):
-        with self.assertRaises(organization.OrganizationCreationError):
+        with self.assertRaises(organization.OrganizationInformationCreationError):
             organization.new_organization_info_located(
                 self.cursor, None, None, None, None
             )
@@ -234,7 +234,7 @@ class test_organization_information(unittest.TestCase):
         self.assertEqual(data[3], self.location_id)
 
     def test_get_organization_info_not_found(self):
-        with self.assertRaises(organization.OrganizationNotFoundError):
+        with self.assertRaises(organization.OrganizationInformationNotFoundError):
             organization.get_organization_info(self.cursor, str(uuid.uuid4()))
 
     def test_update_organization_info(self):

--- a/tests/fertiscan/db/test_sub_label.py
+++ b/tests/fertiscan/db/test_sub_label.py
@@ -50,7 +50,7 @@ class test_sub_type(unittest.TestCase):
         self.assertEqual(str(data_fr), str(sub_type_id))
 
     def test_get_sub_type_id_not_found(self):
-        with self.assertRaises(sub_label.SubTypeNotFoundError):
+        with self.assertRaises(sub_label.SubTypeQueryError):
             sub_label.get_sub_type_id(self.cursor, "not-a-type")
 
 

--- a/tests/fertiscan/queries/test_query_error_handling.py
+++ b/tests/fertiscan/queries/test_query_error_handling.py
@@ -1,0 +1,67 @@
+import unittest
+
+from psycopg import Error as PsycopgError
+
+from fertiscan.db.queries.errors import QueryError, handle_query_errors
+
+
+class TestHandleQueryErrors(unittest.TestCase):
+    # Test to ensure the decorated function runs successfully without errors
+    def test_successful_function_execution(self):
+        @handle_query_errors()
+        def successful_function():
+            return "Success"
+
+        self.assertEqual(successful_function(), "Success")
+
+    # Test to verify that QueryError and its subclasses are raised as-is
+    def test_query_error_propagation(self):
+        class CustomQueryError(QueryError):
+            pass
+
+        @handle_query_errors()
+        def function_raises_query_error():
+            raise CustomQueryError("Test query error")
+
+        with self.assertRaises(CustomQueryError):
+            function_raises_query_error()
+
+    # Test to ensure that psycopg DB errors are caught and raised as QueryError
+    def test_db_error_handling(self):
+        @handle_query_errors()
+        def function_raises_db_error():
+            raise PsycopgError("DB error")
+
+        with self.assertRaises(QueryError) as cm:
+            function_raises_db_error()
+
+        self.assertIn("Database error: DB error", str(cm.exception))
+
+    # Test to ensure any unexpected exceptions are caught and raised as QueryError
+    def test_unexpected_error_handling(self):
+        @handle_query_errors()
+        def function_raises_unexpected_error():
+            raise ValueError("Some value error")
+
+        with self.assertRaises(QueryError) as cm:
+            function_raises_unexpected_error()
+
+        self.assertIn("Unexpected error: Some value error", str(cm.exception))
+
+    # Test to check custom error class handling in the decorator
+    def test_custom_error_cls(self):
+        class CustomError(Exception):
+            pass
+
+        @handle_query_errors(error_cls=CustomError)
+        def function_raises_db_error():
+            raise PsycopgError("DB error")
+
+        with self.assertRaises(CustomError) as cm:
+            function_raises_db_error()
+
+        self.assertIn("Database error: DB error", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fertiscan/test_datastore.py
+++ b/tests/fertiscan/test_datastore.py
@@ -304,7 +304,7 @@ class TestDatastore(unittest.IsolatedAsyncioTestCase):
 
     def test_register_analysy_missing_key(self):
         self.analysis_json.pop("specification_en", None)
-        with self.assertRaises(fertiscan.data_inspection.MissingKeyError):
+        with self.assertRaises(fertiscan.data_inspection.BuildInspectionImportError):
             asyncio.run(
                 fertiscan.register_analysis(
                     self.cursor,


### PR DESCRIPTION
Changes:

- For each of metadata and queries, there now is a module for all the errors.
- The errors now have a hierarchy which helps when handling a group of exceptions at once

```
Query exceptions hierarchy:

    Exception
    |__QueryError
       |__InspectionQueryError
       |__LabelInformationQueryError
       |__LabelDimensionQueryError
       |__MetricQueryError
       |__UnitQueryError
       |__ElementCompoundQueryError
       |__MicronutrientQueryError
       |__GuaranteedAnalysisQueryError
       |__OrganizationQueryError
       |__OrganizationInformationQueryError
       |__LocationQueryError
       |__RegionQueryError
       |__ProvinceQueryError
       |__SpecificationQueryError
       |__SubLabelQueryError
       |__SubTypeQueryError

Each QueryError sub type exception has specific errors related to creation, retrieval, updating, and deletion, as well as a 'not found' error.
```

```
Metadata exceptions hierarchy:

    Exception
    |__MetadataError
       |__BuildInspectionImportError
       |__BuildInspectionExportError
       |__NPKError
```

- Because the error handling pattern is the same for pretty much all the query functions, we use a decorator to minimize code repetition:
```python
def handle_query_errors(error_cls=QueryError):
    """Decorator for handling query errors."""

    def decorator(func):
        @wraps(func)
        def wrapper(*args, **kwargs):
            try:
                return func(*args, **kwargs)
            except QueryError:
                raise
            except Error as db_error:
                raise error_cls(f"Database error: {db_error}") from db_error
            except Exception as e:
                raise error_cls(f"Unexpected error: {e}") from e

        return wrapper

    return decorator

```

The code using a decorator:

```python
@handle_query_errors(LabelInformationRetrievalError)
def get_label_information_json(cursor, label_info_id) -> dict:
    query = """
        SELECT get_label_info_json(%s);
        """
    cursor.execute(query, (str(label_info_id),))
    label_info = cursor.fetchone()
    if label_info is None or label_info[0] is None:
        raise LabelInformationNotFoundError(
            "Error: could not get the label information: " + str(label_info_id)
        )
    return label_info[0]
```

is equivalent to:

```python
def get_label_information_json(cursor, label_info_id) -> dict:
    try:
        query = """
            SELECT get_label_info_json(%s);
            """
        cursor.execute(query, (str(label_info_id),))
        label_info = cursor.fetchone()
        if label_info is None or label_info[0] is None:
            raise LabelInformationNotFoundError(
                "Error: could not get the label information: " + str(label_info_id)
            )
        return label_info[0]
    except QueryError:
        raise
    except Error as db_error:
        raise LabelInformationRetrievalError(f"Database error: {db_error}") from db_error
    except Exception as e:
        raise LabelInformationRetrievalError(f"Unexpected error: {e}") from e
```

Note that `LabelInformationNotFoundError` is a `QueryError`.



