### PR TITLE
Issue 205: trigger release when pyproject is udpated

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -22,6 +22,8 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files: |
+            nachet_pyproject.toml
+            fertiscan_pyproject.toml
             nachet/**
             fertiscan/**
             datastore/**
@@ -76,7 +78,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Trigger Release Workflow for Nachet
-        if: contains(needs.get-changed-files.outputs.files, 'nachet/') || contains(needs.get-changed-files.outputs.files, 'datastore/')
+        if: contains(needs.get-changed-files.outputs.files, 'nachet_pyproject.toml')
         run: |
           gh workflow run publish-package.yml \
           --ref main \
@@ -85,7 +87,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trigger Release Workflow for Fertiscan
-        if: contains(needs.get-changed-files.outputs.files, 'fertiscan/') || contains(needs.get-changed-files.outputs.files, 'datastore/')
+        if: contains(needs.get-changed-files.outputs.files, 'fertiscan_pyproject.toml')
         run: |
           gh workflow run publish-package.yml \
           --ref main \


### PR DESCRIPTION
Updated the pipeline to automatically trigger a release upon a version being bumped in either nachet_pyproject.toml or fertiscan_pyproject.toml instead of detecting files changes. 

I want to specify that version bumped check is only being triggered when changes are made to either fertiscan, nachet or datastore folder. I did it this way since making modifications in anny other file/folder doesnt impact the packages annd should not trigger necessarly a release. For example : https://github.com/ai-cfia/ailab-datastore/pull/178. It wasnt expected to trigger a release since changes aren't made to packages. 

At least now if version is bumped then the release creation gets trigger. It should handle edge cases like #178. 