### PR TITLE
issue #255: fix `get_blob was never awaited` in `get_picture_set_pictures`

### DIFF
--- a/datastore/__init__.py
+++ b/datastore/__init__.py
@@ -255,7 +255,7 @@ async def get_picture_set_pictures(cursor, user_id, picture_set_id, container_cl
                 blob_link = azure_storage.build_blob_name(
                     str(picture_set_name), str(pic_id), None
                 )
-            blob_obj = azure_storage.get_blob(container_client, blob_link)
+            blob_obj = await azure_storage.get_blob(container_client, blob_link)
             pic_metadata.pop("link", None)
             pic_metadata["blob"] = blob_obj
             result.append(pic_metadata)

--- a/fertiscan_pyproject.toml
+++ b/fertiscan_pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fertiscan_datastore"
-version = "1.0.16"
+version = "1.0.17"
 authors = [
   { name="Francois Werbrouck", email="francois.werbrouck@inspection.gc.ca" },
   { name="Kotchikpa Guy-Landry Allagbe" , email = "kotchikpaguy-landry.allagbe@inspection.gc.ca"}

--- a/nachet_pyproject.toml
+++ b/nachet_pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nachet_datastore"
-version = "1.0.4"
+version = "1.0.5"
 authors = [
   { name="Francois Werbrouck", email="francois.werbrouck@inspection.gc.ca" },
   { name="Sylvanie You", email="Sylvanie.You@inspection.gc.ca"}

--- a/tests/fertiscan/db/test_metric.py
+++ b/tests/fertiscan/db/test_metric.py
@@ -190,8 +190,9 @@ class test_metric(unittest.TestCase):
         metric_data = metric.get_metrics_json(self.cursor, self.label_id)
 
         self.assertEqual(metric_data["volume"]["unit"], volume_unit)
-        self.assertEqual(metric_data["weight"][0]["unit"], weight_unit_imperial)
-        self.assertEqual(metric_data["weight"][1]["unit"], weight_unit_metric)
+        weight_units = {entry["unit"] for entry in metric_data["weight"]}
+        self.assertIn(weight_unit_imperial, weight_units)
+        self.assertIn(weight_unit_metric, weight_units)
         self.assertEqual(metric_data["density"]["unit"], density_unit)
 
     def test_get_metrics_json_empty(self):

--- a/tests/fertiscan/test_datastore.py
+++ b/tests/fertiscan/test_datastore.py
@@ -684,3 +684,27 @@ class TestDatastore(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(new_label_dimension[9]), new_guaranteed_nb)
         self.assertNotEqual(len(new_label_dimension[9]), len(old_label_dimension[12]))
         self.assertNotEqual(len(new_label_dimension[9]), old_guaranteed_nb)
+
+    def test_get_picture_set_pictures(self):
+        picture_set_id = asyncio.run(
+            datastore.create_picture_set(
+                self.cursor, self.container_client, 3, self.user.id, "test_folder"
+            )
+        )
+        picture_ids = asyncio.run(
+            datastore.upload_pictures(
+                self.cursor,
+                self.user.id,
+                [self.pic_encoded, self.pic_encoded, self.pic_encoded],
+                self.container_client,
+                picture_set_id,
+            )
+        )
+        pictures = asyncio.run(
+            datastore.get_picture_set_pictures(
+                self.cursor, self.user.id, picture_set_id, self.container_client
+            )
+        )
+        self.assertEqual(len(pictures), 3)
+        for p in pictures:
+            self.assertTrue(p["id"] in picture_ids)


### PR DESCRIPTION
- [x] await azure_storage.get_blob

> [!CAUTION]
> Done in `datastore` which affects Nachet as well. Hence version bump for Nachet. Please check that nothing was broken.